### PR TITLE
202303 melhoria esparsidade estrutura com iteradores periodos

### DIFF
--- a/src/C_ModeloOtimizacao.h
+++ b/src/C_ModeloOtimizacao.h
@@ -736,7 +736,7 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 
 
 		template<typename TListasIdxElem, typename TIt>
-		void alocConteudoIter(TListasIdxElem& a_listasIdxElem, const TIt a_it) {
+		std::vector<TIt> alocConteudoIter(TListasIdxElem& a_listasIdxElem, const TIt a_it) {
 			try {
 
 				// Inicializa Lista
@@ -759,29 +759,51 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 					a_listasIdxElem.addElemento(a_it, a_listasIdxElem.getTipoElemento());
 				}
 
-				//else
-					//a_listasIdxElem.alterarValorSeAlterarIterador(a_it, a_listasIdxElem.getTipoElemento());
+				if (!a_listasIdxElem.isIteradorValido(a_it))
+					return a_listasIdxElem.getIteradores(a_it);
+
+				return std::vector<TIt>();
 
 			}
 			catch (const std::exception& erro) { throw std::invalid_argument("alocConteudoIter(a_listasIdxElem," + getFullString(a_it) + "): \n" + std::string(erro.what())); }
 		};
 
+		template<typename TListasIdxElem, typename TIt>
+		void tratConteudoIter(TListasIdxElem& a_listasIdxElem, const TIt a_it) {
+			try {
+
+		        const std::vector<TIt> iteradores_multiplos = alocConteudoIter(a_listasIdxElem, a_it);
+
+				if (iteradores_multiplos.size() <= 1)
+					return;
+
+				for (int i = 0; i < int(iteradores_multiplos.size()); i++) {
+					if (a_listasIdxElem.at(iteradores_multiplos.at(i)).size() > 0)
+						throw std::invalid_argument("Nao foi possivel alocar conteudo devido a existencia de multiplos iteradores com elementos em " + getString(iteradores_multiplos.at(i)));
+				}
+
+				a_listasIdxElem.alterarValorSeAlterarIterador(a_it, a_listasIdxElem.getTipoElemento());
+
+			}
+			catch (const std::exception& erro) { throw std::invalid_argument("tratConteudoIter(a_listasIdxElem," + getFullString(a_it) + "): \n" + std::string(erro.what())); }
+		};
 		
 		template<typename TListasIdxElem, typename TConteudo, typename TIt1, typename TIt2, typename TIt3, typename TIt4, typename TIt5, typename TIt6, typename TIt7, typename TIt8, typename TIt9, typename TIt10>
 		void addConteudoIters_10(TListasIdxElem& a_listasIdxElem, TConteudo& a_conteudo, const TIt1 a_it1, const TIt2 a_it2, const TIt3 a_it3, const TIt4 a_it4, const TIt5 a_it5, const TIt6 a_it6, const TIt7 a_it7, const TIt8 a_it8, const TIt9 a_it9, const TIt10 a_it10) {
 
 			try {
 
-				alocConteudoIter(a_listasIdxElem, a_it1);
-				alocConteudoIter(a_listasIdxElem.at(a_it1), a_it2);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2), a_it3);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3), a_it4);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4), a_it5);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5), a_it6);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6), a_it7);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7), a_it8);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8), a_it9);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9), a_it10);
+				tratConteudoIter(a_listasIdxElem, a_it1);
+				tratConteudoIter(a_listasIdxElem.at(a_it1), a_it2);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2), a_it3);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3), a_it4);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4), a_it5);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5), a_it6);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6), a_it7);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7), a_it8);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8), a_it9);
+				if (alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9), a_it10).size() > 1)
+					throw std::invalid_argument("Multiplos iteradores na ultima camada.");
 
 				a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).setElemento(a_it10, a_conteudo);
 
@@ -794,17 +816,18 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 
 			try {
 
-				alocConteudoIter(a_listasIdxElem, a_it1);
-				alocConteudoIter(a_listasIdxElem.at(a_it1), a_it2);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2), a_it3);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3), a_it4);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4), a_it5);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5), a_it6);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6), a_it7);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7), a_it8);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8), a_it9);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9), a_it10);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10), a_it11);
+				tratConteudoIter(a_listasIdxElem, a_it1);
+				tratConteudoIter(a_listasIdxElem.at(a_it1), a_it2);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2), a_it3);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3), a_it4);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4), a_it5);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5), a_it6);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6), a_it7);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7), a_it8);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8), a_it9);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9), a_it10);
+				if (alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10), a_it11).size() > 1)
+					throw std::invalid_argument("Multiplos iteradores na ultima camada.");
 
 				a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).setElemento(a_it11, a_conteudo);
 
@@ -817,18 +840,19 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 
 			try {
 
-				alocConteudoIter(a_listasIdxElem, a_it1);
-				alocConteudoIter(a_listasIdxElem.at(a_it1), a_it2);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2), a_it3);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3), a_it4);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4), a_it5);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5), a_it6);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6), a_it7);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7), a_it8);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8), a_it9);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9), a_it10);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10), a_it11);
-				alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11), a_it12);
+				tratConteudoIter(a_listasIdxElem, a_it1);
+				tratConteudoIter(a_listasIdxElem.at(a_it1), a_it2);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2), a_it3);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3), a_it4);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4), a_it5);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5), a_it6);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6), a_it7);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7), a_it8);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8), a_it9);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9), a_it10);
+				tratConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10), a_it11);
+				if (alocConteudoIter(a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11), a_it12).size() > 1)
+					throw std::invalid_argument("Multiplos iteradores na ultima camada.");
 
 				a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11).setElemento(a_it12, a_conteudo);
 
@@ -1019,73 +1043,22 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 
 			try {
 
-				if (a_listasIdxElem.size() == 0)
-					return false;
-				else if (a_listasIdxElem.getIteradorFinal() < a_it1)
-					return false;
-				else if (a_it1 < a_listasIdxElem.getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).getIteradorFinal() < a_it2)
-					return false;
-				else if (a_it2 < a_listasIdxElem.at(a_it1).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).getIteradorFinal() < a_it3)
-					return false;
-				else if (a_it3 < a_listasIdxElem.at(a_it1).at(a_it2).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).getIteradorFinal() < a_it4)
-					return false;
-				else if (a_it4 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).getIteradorFinal() < a_it5)
-					return false;
-				else if (a_it5 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).getIteradorFinal() < a_it6)
-					return false;
-				else if (a_it6 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).getIteradorFinal() < a_it7)
-					return false;
-				else if (a_it7 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).getIteradorFinal() < a_it8)
-					return false;
-				else if (a_it8 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).getIteradorFinal() < a_it9)
-					return false;
-				else if (a_it9 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).getIteradorFinal() < a_it10)
-					return false;
-				else if (a_it10 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).getIteradorInicial())
-					return false;
-
+				if (!a_listasIdxElem.isIteradorValido(a_it1)) return false;
+				else if (!a_listasIdxElem.at(a_it1).isIteradorValido(a_it2)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).isIteradorValido(a_it3)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).isIteradorValido(a_it4)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).isIteradorValido(a_it5)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).isIteradorValido(a_it6)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).isIteradorValido(a_it7)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).isIteradorValido(a_it8)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).isIteradorValido(a_it9)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).isIteradorValido(a_it10)) return false;
 				a_conteudo = a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10);
 				return true;
 
 			}
 			catch (const std::exception& erro) {
-				throw std::invalid_argument("getConteudoIters(" + getFullString(a_it1) + "," + getFullString(a_it2) + "," + getFullString(a_it3) + "," + getFullString(a_it4) + "," + getFullString(a_it5) + "," + getFullString(a_it6) + "," + getFullString(a_it7) + "," + getFullString(a_it8) + "," + getFullString(a_it9) + "," + getFullString(a_it10) + "): \n" + std::string(erro.what()));
+				throw std::invalid_argument("getConteudoIters_10(" + getFullString(a_it1) + "," + getFullString(a_it2) + "," + getFullString(a_it3) + "," + getFullString(a_it4) + "," + getFullString(a_it5) + "," + getFullString(a_it6) + "," + getFullString(a_it7) + "," + getFullString(a_it8) + "," + getFullString(a_it9) + "," + getFullString(a_it10) + "): \n" + std::string(erro.what()));
 			}
 		};
 
@@ -1094,79 +1067,24 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 
 			try {
 
-				if (a_listasIdxElem.size() == 0)
-					return false;
-				else if (a_listasIdxElem.getIteradorFinal() < a_it1)
-					return false;
-				else if (a_it1 < a_listasIdxElem.getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).getIteradorFinal() < a_it2)
-					return false;
-				else if (a_it2 < a_listasIdxElem.at(a_it1).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).getIteradorFinal() < a_it3)
-					return false;
-				else if (a_it3 < a_listasIdxElem.at(a_it1).at(a_it2).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).getIteradorFinal() < a_it4)
-					return false;
-				else if (a_it4 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).getIteradorFinal() < a_it5)
-					return false;
-				else if (a_it5 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).getIteradorFinal() < a_it6)
-					return false;
-				else if (a_it6 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).getIteradorFinal() < a_it7)
-					return false;
-				else if (a_it7 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).getIteradorFinal() < a_it8)
-					return false;
-				else if (a_it8 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).getIteradorFinal() < a_it9)
-					return false;
-				else if (a_it9 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).getIteradorFinal() < a_it10)
-					return false;
-				else if (a_it10 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).getIteradorFinal() < a_it11)
-					return false;
-				else if (a_it11 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).getIteradorInicial())
-					return false;
+				if (!a_listasIdxElem.isIteradorValido(a_it1)) return false;
+				else if (!a_listasIdxElem.at(a_it1).isIteradorValido(a_it2)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).isIteradorValido(a_it3)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).isIteradorValido(a_it4)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).isIteradorValido(a_it5)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).isIteradorValido(a_it6)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).isIteradorValido(a_it7)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).isIteradorValido(a_it8)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).isIteradorValido(a_it9)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).isIteradorValido(a_it10)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).isIteradorValido(a_it11)) return false;
 
 				a_conteudo = a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11);
 				return true;
 
 			}
 			catch (const std::exception& erro) {
-				throw std::invalid_argument("getConteudoIters(" + getFullString(a_it1) + "," + getFullString(a_it2) + "," + getFullString(a_it3) + "," + getFullString(a_it4) + "," + getFullString(a_it5) + "," + getFullString(a_it6) + "," + getFullString(a_it7) + "," + getFullString(a_it8) + "," + getFullString(a_it9) + "," + getFullString(a_it10) + "," + getFullString(a_it11) + "): \n" + std::string(erro.what()));
+				throw std::invalid_argument("getConteudoIters_11(" + getFullString(a_it1) + "," + getFullString(a_it2) + "," + getFullString(a_it3) + "," + getFullString(a_it4) + "," + getFullString(a_it5) + "," + getFullString(a_it6) + "," + getFullString(a_it7) + "," + getFullString(a_it8) + "," + getFullString(a_it9) + "," + getFullString(a_it10) + "," + getFullString(a_it11) + "): \n" + std::string(erro.what()));
 			}
 		};
 
@@ -1175,84 +1093,24 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 
 			try {
 
-				if (a_listasIdxElem.size() == 0)
-					return false;
-				else if (a_listasIdxElem.getIteradorFinal() < a_it1)
-					return false;
-				else if (a_it1 < a_listasIdxElem.getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).getIteradorFinal() < a_it2)
-					return false;
-				else if (a_it2 < a_listasIdxElem.at(a_it1).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).getIteradorFinal() < a_it3)
-					return false;
-				else if (a_it3 < a_listasIdxElem.at(a_it1).at(a_it2).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).getIteradorFinal() < a_it4)
-					return false;
-				else if (a_it4 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).getIteradorFinal() < a_it5)
-					return false;
-				else if (a_it5 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).getIteradorFinal() < a_it6)
-					return false;
-				else if (a_it6 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).getIteradorFinal() < a_it7)
-					return false;
-				else if (a_it7 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).getIteradorFinal() < a_it8)
-					return false;
-				else if (a_it8 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).getIteradorFinal() < a_it9)
-					return false;
-				else if (a_it9 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).getIteradorFinal() < a_it10)
-					return false;
-				else if (a_it10 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).getIteradorFinal() < a_it11)
-					return false;
-				else if (a_it11 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).getIteradorInicial())
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11).size() == 0)
-					return false;
-				else if (a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11).getIteradorFinal() < a_it12)
-					return false;
-				else if (a_it12 < a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11).getIteradorInicial())
-					return false;
+				if (!a_listasIdxElem.isIteradorValido(a_it1)) return false;
+				else if (!a_listasIdxElem.at(a_it1).isIteradorValido(a_it2)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).isIteradorValido(a_it3)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).isIteradorValido(a_it4)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).isIteradorValido(a_it5)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).isIteradorValido(a_it6)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).isIteradorValido(a_it7)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).isIteradorValido(a_it8)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).isIteradorValido(a_it9)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).isIteradorValido(a_it10)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).isIteradorValido(a_it11)) return false;
+				else if (!a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11).isIteradorValido(a_it12)) return false;
 
 				a_conteudo = a_listasIdxElem.at(a_it1).at(a_it2).at(a_it3).at(a_it4).at(a_it5).at(a_it6).at(a_it7).at(a_it8).at(a_it9).at(a_it10).at(a_it11).at(a_it12);
 				return true;
 
 			}
-			catch (const std::exception& erro) { throw std::invalid_argument("getConteudoIters(" + getFullString(a_it1) + "," + getFullString(a_it2) + "," + getFullString(a_it3) + "," + getFullString(a_it4) + "," + getFullString(a_it5) + "," + getFullString(a_it6) + "," + getFullString(a_it7) + "," + getFullString(a_it8) + "," + getFullString(a_it9) + "," + getFullString(a_it10) + "," + getFullString(a_it11) + "," + getFullString(a_it12) + "): \n" + std::string(erro.what())); }
+			catch (const std::exception& erro) { throw std::invalid_argument("getConteudoIters12(" + getFullString(a_it1) + "," + getFullString(a_it2) + "," + getFullString(a_it3) + "," + getFullString(a_it4) + "," + getFullString(a_it5) + "," + getFullString(a_it6) + "," + getFullString(a_it7) + "," + getFullString(a_it8) + "," + getFullString(a_it9) + "," + getFullString(a_it10) + "," + getFullString(a_it11) + "," + getFullString(a_it12) + "): \n" + std::string(erro.what())); }
 		};
 
 			VARIAVEL_DECISAO_2(DECLARAR_METODOS_ELEMENTO)

--- a/src/C_ModeloOtimizacao.h
+++ b/src/C_ModeloOtimizacao.h
@@ -736,7 +736,7 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 
 
 		template<typename TListasIdxElem, typename TIt>
-		void alocConteudoIter(TListasIdxElem& a_listasIdxElem, TIt a_it) {
+		void alocConteudoIter(TListasIdxElem& a_listasIdxElem, const TIt a_it) {
 			try {
 
 				// Inicializa Lista
@@ -745,23 +745,28 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 
 				// Alocação do final da lista até iterador informado
 				else if (a_listasIdxElem.getIteradorFinal() < a_it) {
-					for (TIt it = a_listasIdxElem.getIteradorFinal(); it < a_it; a_listasIdxElem.incrementarIterador(it))
-						if (it > a_listasIdxElem.getIteradorFinal())
+					for (TIt it = a_listasIdxElem.getIteradorFinal(); it < a_it; a_listasIdxElem.incrementarIteradorMinimo(it))
+						if (it >= a_listasIdxElem.getIteradorFinal() + 1)
 							a_listasIdxElem.addElemento(it, a_listasIdxElem.getTipoElemento());
 					a_listasIdxElem.addElemento(a_it, a_listasIdxElem.getTipoElemento());
 				}
 
 				// Alocação do início da lista até o iterador informado
 				else if (a_it < a_listasIdxElem.getIteradorInicial()) {
-					for (TIt it = a_listasIdxElem.getIteradorInicial(); it > a_it; a_listasIdxElem.decrementarIterador(it))
+					for (TIt it = a_listasIdxElem.getIteradorInicial(); it >= a_it + 1; a_listasIdxElem.decrementarIteradorMinimo(it))
 						if (it < a_listasIdxElem.getIteradorInicial())
 							a_listasIdxElem.addElemento(it, a_listasIdxElem.getTipoElemento());
 					a_listasIdxElem.addElemento(a_it, a_listasIdxElem.getTipoElemento());
 				}
+
+				//else
+					//a_listasIdxElem.alterarValorSeAlterarIterador(a_it, a_listasIdxElem.getTipoElemento());
+
 			}
 			catch (const std::exception& erro) { throw std::invalid_argument("alocConteudoIter(a_listasIdxElem," + getFullString(a_it) + "): \n" + std::string(erro.what())); }
 		};
 
+		
 		template<typename TListasIdxElem, typename TConteudo, typename TIt1, typename TIt2, typename TIt3, typename TIt4, typename TIt5, typename TIt6, typename TIt7, typename TIt8, typename TIt9, typename TIt10>
 		void addConteudoIters_10(TListasIdxElem& a_listasIdxElem, TConteudo& a_conteudo, const TIt1 a_it1, const TIt2 a_it2, const TIt3 a_it3, const TIt4 a_it4, const TIt5 a_it5, const TIt6 a_it6, const TIt7 a_it7, const TIt8 a_it8, const TIt9 a_it9, const TIt10 a_it10) {
 
@@ -1004,17 +1009,7 @@ DEFINE_SMART_ELEMENTO(ModeloOtimizacao, SMART_ELEMENTO_MODELO_OTIMIZACAO)
 					return true;
 
 			}
-			//catch (const std::exception& erro) { throw std::invalid_argument("varredurasIters_10(" + getFullString(a_it1) + "," + getFullString(a_it2) + "," + getFullString(a_it3) + "," + getFullString(a_it4) + "," + getFullString(a_it5) + "," + getFullString(a_it6) + "," + getFullString(a_it7) + "," + getFullString(a_it8) + "," + getFullString(a_it9) + "," + getFullString(a_it10) + "): \n" + std::string(erro.what())); }
-			catch (const std::exception& erro) {
-
-				std::cout << std::string(erro.what()) << std::endl;
-
-			}
-
-			this;
-
-			return false;
-
+			catch (const std::exception& erro) { throw std::invalid_argument("varredurasIters_10(" + getFullString(a_it1) + "," + getFullString(a_it2) + "," + getFullString(a_it3) + "," + getFullString(a_it4) + "," + getFullString(a_it5) + "," + getFullString(a_it6) + "," + getFullString(a_it7) + "," + getFullString(a_it8) + "," + getFullString(a_it9) + "," + getFullString(a_it10) + "): \n" + std::string(erro.what())); }
 
 		};
 

--- a/src/C_ModeloOtimizacao_multiestagio_estocastico.cpp
+++ b/src/C_ModeloOtimizacao_multiestagio_estocastico.cpp
@@ -272,10 +272,10 @@ void ModeloOtimizacao::formularModeloOtimizacao(Dados& a_dados, EntradaSaidaDado
 
 				if (listaTipoSubproblemaSolver.at(i) != TipoSubproblemaSolver_mestre) {
 
-					alocarVarDecisao_YH_3(listaTipoSubproblemaSolver.at(i), idEstagio, alocacao_afluencia_incremental.at(idEstagio));
-					alocarVarDecisao_YHF_3(listaTipoSubproblemaSolver.at(i), idEstagio, alocacao_afluencia_incremental.at(idEstagio));
+					//alocarVarDecisao_YH_3(listaTipoSubproblemaSolver.at(i), idEstagio, alocacao_afluencia_incremental.at(idEstagio));
+					//alocarVarDecisao_YHF_3(listaTipoSubproblemaSolver.at(i), idEstagio, alocacao_afluencia_incremental.at(idEstagio));
 
-					alocarVarDecisao_QDEF_3(listaTipoSubproblemaSolver.at(i), idEstagio, alocacao_defluencia.at(idEstagio));
+					//alocarVarDecisao_QDEF_3(listaTipoSubproblemaSolver.at(i), idEstagio, alocacao_defluencia.at(idEstagio));
 
 				} // if (listaTipoSubproblemaSolver.at(i) != TipoSubproblemaSolver_mestre) {
 

--- a/src/C_SmartEnupla.h
+++ b/src/C_SmartEnupla.h
@@ -157,6 +157,19 @@ public:
 		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::at(" + getFullString(a_iterador) + "): \n" + std::string(erro.what())); }
 	}; // void addElemento(TipoIterador a_iterador, TipoValor a_valor) {
 
+	void alterarValorSeAlterarIterador(const TipoIterador a_iterador, const TipoValor a_valor) {
+		try {
+
+			if ((getIteradorInicial() <= a_iterador) && (a_iterador <= getIteradorFinal()))
+				return;
+			
+			throw std::invalid_argument("Metodo nao valido para TipoIterador e TipoValor");
+
+
+		} // try{
+		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::alterarValorSeAlterarIterador(" + getFullString(a_iterador) + ",a_valor) : \n" + std::string(erro.what())); }
+	}
+
 	void random_shuffle() { std::random_shuffle(smartEnupla.begin(), smartEnupla.end()); };
 
 
@@ -188,6 +201,8 @@ public:
 		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::incrementaIterador(" + getString(a_iterador) + "," + getString(a_inteiro) + "): \n" + std::string(erro.what())); }
 	} // void incrementarIterador(Periodo &a_periodo, const int a_inteiro) const {
 
+	void incrementarIteradorMinimo(TipoIterador& a_iterador) const { incrementarIterador(a_iterador); }
+
 	void incrementarIterador(TipoIterador& a_iterador) const {
 		try {
 			if (size() == 0)
@@ -200,6 +215,8 @@ public:
 		} // try{
 		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::incrementaIterador(" + getString(a_iterador) + "): \n" + std::string(erro.what())); }
 	} // void operator++(Periodo &a_periodo) const {
+
+	void decrementarIteradorMinimo(TipoIterador& a_iterador) const { decrementarIterador(a_iterador); }
 
 	void decrementarIterador(TipoIterador& a_iterador) const {
 		try {
@@ -635,13 +652,21 @@ public:
 			if (size() == 0)
 				throw std::invalid_argument("Iteradores nao definidos.");
 
+			Periodo periodo_inicial;
+
+			const int indice_estrutura = getIndiceEstruturaSeExistir(a_periodo_externo);
+			if (indice_estrutura > -1)
+				periodo_inicial = lista_estrutura.at(indice_estrutura).iteradores_iniciais.at(lista_estrutura.at(indice_estrutura).tipo_iterador_inicial).at(0);
+			else
+				periodo_inicial = getIteradorInicial();
+
 			const Periodo periodo_externo_seguinte = a_periodo_externo + 1;
 
 			std::vector<Periodo> iteradores;
 
 			bool is_sobreposicao = false;
 
-			for (Periodo periodo_interno = getIteradorInicial(); periodo_interno <= getIteradorFinal(); incrementarIterador(periodo_interno)) {
+			for (Periodo periodo_interno = periodo_inicial; periodo_interno <= getIteradorFinal(); incrementarIterador(periodo_interno)) {
 
 				const double sobreposicao = a_periodo_externo.sobreposicao(periodo_interno);
 
@@ -696,6 +721,16 @@ public:
 		} // try{
 		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::incrementaIterador(" + getString(a_periodo) + "," + getString(a_inteiro) + "): \n" + std::string(erro.what())); }
 	} // void incrementarIterador(Periodo &a_periodo, const int a_inteiro) const {
+
+	void incrementarIteradorMinimo(Periodo& a_periodo) const {
+		try {
+			
+			a_periodo = Periodo(TipoPeriodo_meia_hora, a_periodo) + 1;
+
+		} // try{
+		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::incrementarIteradorMinimo(" + getString(a_periodo) + "): \n" + std::string(erro.what())); }
+
+	}
 
 	void incrementarIterador(Periodo& a_periodo) const {
 		try {
@@ -783,6 +818,16 @@ public:
 		} // try{
 		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::incrementaIterador(" + getString(a_periodo) + "): \n" + std::string(erro.what())); }
 	} // void operator++(Periodo &a_periodo) const {
+
+	void decrementarIteradorMinimo(Periodo& a_periodo) const {
+		try {
+
+			a_periodo = Periodo(TipoPeriodo_meia_hora, a_periodo) - 1;
+
+		} // try{
+		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::incrementarIteradorMinimo(" + getString(a_periodo) + "): \n" + std::string(erro.what())); }
+
+	}
 
 	void decrementarIterador(Periodo& a_periodo) const {
 		try {
@@ -917,7 +962,7 @@ public:
 
 					else if ((lista_estrutura.at(0).tipoEstruturaPeriodo == TipoEstruturaPeriodo_crescente && a_iterador.getTipoPeriodo() < lista_estrutura.at(0).tipo_iterador_inicial) \
 						|| (lista_estrutura.at(0).tipoEstruturaPeriodo == TipoEstruturaPeriodo_decrescente && a_iterador.getTipoPeriodo() > lista_estrutura.at(0).tipo_iterador_inicial)) {
-						inicializacaoEstruturaPeriodo(true, 0);//Cria uma nova estrutura
+						inicializacaoEstruturaPeriodo(0, 0);//Cria uma nova estrutura
 						lista_estrutura.at(0).tipo_iterador_final = a_iterador.getTipoPeriodo();
 					}
 
@@ -966,7 +1011,7 @@ public:
 
 					else if ((lista_estrutura.at(int(lista_estrutura.size()) - 1).tipoEstruturaPeriodo == TipoEstruturaPeriodo_crescente && a_iterador.getTipoPeriodo() > lista_estrutura.at(int(lista_estrutura.size()) - 1).tipo_iterador_final) \
 						|| (lista_estrutura.at(int(lista_estrutura.size()) - 1).tipoEstruturaPeriodo == TipoEstruturaPeriodo_decrescente && a_iterador.getTipoPeriodo() < lista_estrutura.at(int(lista_estrutura.size()) - 1).tipo_iterador_final)) {
-						inicializacaoEstruturaPeriodo(false, 0);//Cria uma nova estrutura
+						inicializacaoEstruturaPeriodo(-1, 0);//Cria uma nova estrutura
 						lista_estrutura.at(int(lista_estrutura.size()) - 1).tipo_iterador_inicial = a_iterador.getTipoPeriodo();
 					}
 
@@ -994,6 +1039,341 @@ public:
 		} // try{
 		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::addElemento(" + getString(a_iterador) + "," + getString(a_valor) + "): \n" + std::string(erro.what())); }
 	}; // void addElemento(Periodo a_iterador, TipoValor a_valor) {
+
+
+	void alterarValorSeAlterarIterador(const Periodo a_iterador, TipoValor a_valor) {
+		try {
+
+			std::vector<Periodo> iteradores = getIteradores(a_iterador);
+
+			if (iteradores.size() == 0)
+				throw std::invalid_argument("Nao ha iteradores compativeis.");
+			else if (iteradores.size() == 1) {
+				if (iteradores.at(0) == a_iterador)
+					return;
+			}
+
+			const Periodo periodo_inicial_orig = iteradores.at(0);
+			const Periodo periodo_final_orig = iteradores.at(iteradores.size() - 1);
+
+			if ((Periodo(periodo_inicial_orig.getTipoPeriodo(), a_iterador) != periodo_inicial_orig) || \
+				(Periodo(periodo_final_orig.getTipoPeriodo(), a_iterador + 1) - 1 != periodo_final_orig))
+					throw std::invalid_argument("Periodo nao se encaixa exatamente em range de iteradores.");
+
+
+			TipoEstruturaPeriodo tipo_estrutura_anterior = TipoEstruturaPeriodo_Nenhum;
+			TipoPeriodo tipo_periodo_anterior = TipoPeriodo_Nenhum;
+			int indice_estrutura_anterior = -1;
+			Periodo periodo_anterior = periodo_inicial_orig;
+			if (periodo_inicial_orig > getIteradorInicial()) {
+				decrementarIterador(periodo_anterior);
+				indice_estrutura_anterior = getIndiceEstrutura(periodo_anterior);
+				tipo_estrutura_anterior = lista_estrutura.at(indice_estrutura_anterior).tipoEstruturaPeriodo;
+				tipo_periodo_anterior = periodo_anterior.getTipoPeriodo();
+			}
+
+			TipoEstruturaPeriodo tipo_estrutura_posterior = TipoEstruturaPeriodo_Nenhum;
+			TipoPeriodo tipo_periodo_posterior = TipoPeriodo_Nenhum;
+			int indice_estrutura_posterior = -1;
+			Periodo periodo_posterior = periodo_final_orig; 
+			if (periodo_final_orig < getIteradorFinal()){
+				incrementarIterador(periodo_posterior);
+				indice_estrutura_posterior = getIndiceEstrutura(periodo_posterior);
+				tipo_estrutura_posterior = lista_estrutura.at(indice_estrutura_posterior).tipoEstruturaPeriodo;
+				tipo_periodo_posterior = periodo_posterior.getTipoPeriodo();
+			}
+
+			std::vector<EstruturaPeriodo> lista_estrutura_copia = lista_estrutura;
+
+			bool estruturas_anterior_posterior_duplicadas = false;
+			// Verifica necessidade de duplicar estrutura atual
+			if ((tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum)) {
+				// Caso estruturas anterior e posterior sejam a mesma, duplica-se estrutura para inclusao entre ambas
+				if (indice_estrutura_anterior == indice_estrutura_posterior) {
+					lista_estrutura_copia.insert(lista_estrutura_copia.begin() + indice_estrutura_anterior, lista_estrutura_copia.at(indice_estrutura_anterior));
+					indice_estrutura_posterior++;
+					estruturas_anterior_posterior_duplicadas = true;
+				}
+			}// if ((tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum)) {
+
+			const TipoPeriodo tipo_periodo_iterador = a_iterador.getTipoPeriodo();
+			
+			int status_inclusao_iterador = -1; // -1 Iterador novo em nova estrutura a ser criada | 0 iterador novo na estrutura de inicio | 1 iterador novo na estrutura do fim
+
+			// Iterador novo em toda enupla.
+			if ((tipo_estrutura_anterior == TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior == TipoEstruturaPeriodo_Nenhum))
+				lista_estrutura_copia = std::vector<EstruturaPeriodo>();
+
+			// Iterador novo no inicio da enupla
+			else if ((tipo_estrutura_anterior == TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum)) {
+
+				// Remove estruturas dos periodos que sairao
+				const int nro_estruturas_a_remover = indice_estrutura_posterior;
+				for (int i = 0; i < nro_estruturas_a_remover; i++) {
+					lista_estrutura_copia.erase(lista_estrutura_copia.begin());
+					indice_estrutura_posterior--;
+				}
+
+				// Realiza adequacoes na estrutura posterior
+				if (tipo_periodo_posterior > lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_final) {
+					tipo_estrutura_posterior = TipoEstruturaPeriodo_crescente;
+					if (tipo_periodo_iterador >= tipo_periodo_posterior)
+						status_inclusao_iterador = 1;
+				}
+				else if (tipo_periodo_posterior < lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_final) {
+					tipo_estrutura_posterior = TipoEstruturaPeriodo_decrescente;
+					if (tipo_periodo_iterador <= tipo_periodo_posterior)
+						status_inclusao_iterador = 1;
+				}
+				else if (tipo_periodo_posterior == lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_final) {
+					status_inclusao_iterador = 1;
+					if (tipo_periodo_iterador >= tipo_periodo_posterior)
+						tipo_estrutura_posterior = TipoEstruturaPeriodo_crescente;
+					else if (tipo_periodo_iterador <= tipo_periodo_posterior)
+						tipo_estrutura_posterior = TipoEstruturaPeriodo_decrescente;
+					else
+						tipo_estrutura_posterior = TipoEstruturaPeriodo_flat;
+				}
+
+				lista_estrutura_copia.at(indice_estrutura_posterior).tipoEstruturaPeriodo = tipo_estrutura_posterior;
+					
+			} // else if ((tipo_estrutura_anterior == TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum)) {
+
+			// Iterador novo no final da enupla
+			else if ((tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior == TipoEstruturaPeriodo_Nenhum)) {
+
+				// Remove estruturas dos periodos que sairao
+				const int nro_estruturas_a_remover = lista_estrutura_copia.size() - (indice_estrutura_anterior + 1);
+				for (int i = 0; i < nro_estruturas_a_remover; i++)
+					lista_estrutura_copia.pop_back();
+
+				if (lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_inicial > tipo_periodo_anterior) {
+					tipo_estrutura_anterior = TipoEstruturaPeriodo_crescente;
+					if (tipo_periodo_anterior >= tipo_periodo_iterador)
+						status_inclusao_iterador = 0;
+				}
+				else if (lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_inicial < tipo_periodo_anterior) {
+					tipo_estrutura_anterior = TipoEstruturaPeriodo_decrescente;
+					if (tipo_periodo_anterior <= tipo_periodo_iterador)
+						status_inclusao_iterador = 0;
+				}
+				else if (lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_inicial == tipo_periodo_anterior) {
+					status_inclusao_iterador = 0;
+					if (tipo_periodo_anterior >= tipo_periodo_iterador)
+						tipo_estrutura_anterior = TipoEstruturaPeriodo_crescente;
+					else if (tipo_periodo_anterior <= tipo_periodo_iterador)
+						tipo_estrutura_anterior = TipoEstruturaPeriodo_decrescente;
+					else
+						tipo_estrutura_anterior = TipoEstruturaPeriodo_flat;
+				}
+
+				lista_estrutura_copia.at(indice_estrutura_anterior).tipoEstruturaPeriodo = tipo_estrutura_anterior;
+
+			} // else if ((tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior == TipoEstruturaPeriodo_Nenhum)) {
+
+			// Iterador novo no meio da enupla
+			else if ((tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum)) {
+
+				// Remove estruturas dos periodos que sairao
+				const int nro_estruturas_a_remover = indice_estrutura_posterior - indice_estrutura_anterior - 1;
+				for (int i = 0; i < nro_estruturas_a_remover; i++)
+					lista_estrutura_copia.erase(lista_estrutura_copia.begin() + indice_estrutura_anterior + 1);
+
+				// Realiza adequacoes na estrutura anterior
+				if (lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_inicial > tipo_periodo_anterior) {
+					tipo_estrutura_anterior = TipoEstruturaPeriodo_crescente;
+					if (tipo_periodo_anterior >= tipo_periodo_iterador)
+						status_inclusao_iterador = 0;
+				}
+				else if (lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_inicial < tipo_periodo_anterior) {
+					tipo_estrutura_anterior = TipoEstruturaPeriodo_decrescente;
+					if (tipo_periodo_anterior <= tipo_periodo_iterador)
+						status_inclusao_iterador = 0;
+				}
+				else if (lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_inicial == tipo_periodo_anterior) {
+					status_inclusao_iterador = 0;
+					if (tipo_periodo_anterior >= tipo_periodo_iterador)
+						tipo_estrutura_anterior = TipoEstruturaPeriodo_crescente;
+					else if (tipo_periodo_anterior <= tipo_periodo_iterador)
+						tipo_estrutura_anterior = TipoEstruturaPeriodo_decrescente;
+					else
+						tipo_estrutura_anterior = TipoEstruturaPeriodo_flat;
+				}
+
+				lista_estrutura_copia.at(indice_estrutura_anterior).tipoEstruturaPeriodo = tipo_estrutura_anterior;
+
+				// Realiza adequacoes na estrutura posterior
+				if (tipo_periodo_posterior > lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_final) {
+					tipo_estrutura_posterior = TipoEstruturaPeriodo_crescente;
+					if ((tipo_periodo_iterador >= tipo_periodo_posterior) && (status_inclusao_iterador == -1))
+						status_inclusao_iterador = 1;
+				}
+				else if (tipo_periodo_posterior < lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_final) {
+					tipo_estrutura_posterior = TipoEstruturaPeriodo_decrescente;
+					if ((tipo_periodo_iterador <= tipo_periodo_posterior) && (status_inclusao_iterador == -1))
+						status_inclusao_iterador = 1;
+				}
+				else if (tipo_periodo_posterior == lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_final) {
+					tipo_estrutura_posterior = TipoEstruturaPeriodo_flat;
+					if (status_inclusao_iterador == -1) {
+						status_inclusao_iterador = 1;
+						if (tipo_periodo_iterador >= tipo_periodo_posterior)
+							tipo_estrutura_posterior = TipoEstruturaPeriodo_crescente;
+						else if (tipo_periodo_iterador <= tipo_periodo_posterior)
+							tipo_estrutura_posterior = TipoEstruturaPeriodo_decrescente;
+					}
+				}
+
+				lista_estrutura_copia.at(indice_estrutura_posterior).tipoEstruturaPeriodo = tipo_estrutura_posterior;
+
+			} // else if ((tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum)) {
+
+
+			//
+			// Criacao estrutura intermediaria
+			//
+			if (status_inclusao_iterador == -1) {
+
+				const int indice_nova_estrutura = indice_estrutura_anterior + 1;
+
+				if (true) {
+					EstruturaPeriodo estruturaPeriodo;
+					estruturaPeriodo.tipo_iterador_inicial = TipoPeriodo_Nenhum;
+					estruturaPeriodo.tipo_iterador_final = TipoPeriodo_Nenhum;
+					estruturaPeriodo.iteradores_iniciais = std::vector<std::vector<Periodo>>(TipoPeriodo_Excedente, std::vector<Periodo>());
+					estruturaPeriodo.iteradores_finais = std::vector<std::vector<Periodo>>(TipoPeriodo_Excedente, std::vector<Periodo>());
+					estruturaPeriodo.smartEnupla = std::vector<std::vector<TipoValor>>(TipoPeriodo_Excedente, std::vector<TipoValor>());
+					for (TipoPeriodo tipo = TipoPeriodo(1); tipo < TipoPeriodo_Excedente; tipo++) {
+						estruturaPeriodo.iteradores_iniciais.at(tipo).reserve(1);
+						estruturaPeriodo.iteradores_finais.at(tipo).reserve(1);
+						estruturaPeriodo.smartEnupla.at(tipo).reserve(1);
+					}
+
+					estruturaPeriodo.tipoEstruturaPeriodo = TipoEstruturaPeriodo_flat;
+					lista_estrutura_copia.insert(lista_estrutura_copia.begin() + indice_nova_estrutura, estruturaPeriodo);
+				}
+
+				if (indice_estrutura_posterior > -1)
+					indice_estrutura_posterior++;
+
+				lista_estrutura_copia.at(indice_nova_estrutura).tipoEstruturaPeriodo = TipoEstruturaPeriodo_flat;
+
+				lista_estrutura_copia.at(indice_nova_estrutura).tipo_iterador_inicial = tipo_periodo_iterador;
+				lista_estrutura_copia.at(indice_nova_estrutura).tipo_iterador_final   = tipo_periodo_iterador;
+
+				lista_estrutura_copia.at(indice_nova_estrutura).iteradores_iniciais.at(tipo_periodo_iterador).push_back(a_iterador);
+				lista_estrutura_copia.at(indice_nova_estrutura).iteradores_finais.at(tipo_periodo_iterador).push_back(a_iterador);
+				lista_estrutura_copia.at(indice_nova_estrutura).smartEnupla.at(tipo_periodo_iterador).push_back(a_valor);
+
+			} // if (status_inclusao_iterador == -1) {
+
+			//
+			// Adequacao estrutura anterior
+			//
+			if (tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) {
+
+				TipoPeriodo tipo_periodo_final_estrutura_anterior = lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_final;
+				Periodo periodo_final_estrutura_anterior = lista_estrutura_copia.at(indice_estrutura_anterior).iteradores_finais.at(tipo_periodo_final_estrutura_anterior).at(0);
+
+				while (periodo_final_estrutura_anterior > periodo_anterior) {
+
+					Periodo novo_periodo_final_estrutura_anterior = periodo_final_estrutura_anterior;
+					decrementarIterador(novo_periodo_final_estrutura_anterior);
+
+					TipoPeriodo novo_tipo_periodo_final_estrutura_anterior = novo_periodo_final_estrutura_anterior.getTipoPeriodo();
+
+					if (novo_tipo_periodo_final_estrutura_anterior == tipo_periodo_final_estrutura_anterior) {
+						lista_estrutura_copia.at(indice_estrutura_anterior).iteradores_finais.at(tipo_periodo_final_estrutura_anterior).at(0) = novo_periodo_final_estrutura_anterior;
+						lista_estrutura_copia.at(indice_estrutura_anterior).smartEnupla.at(tipo_periodo_final_estrutura_anterior).pop_back();
+					}
+					else{
+						lista_estrutura_copia.at(indice_estrutura_anterior).iteradores_iniciais.at(tipo_periodo_final_estrutura_anterior) = std::vector<Periodo>();
+						lista_estrutura_copia.at(indice_estrutura_anterior).iteradores_finais.at(tipo_periodo_final_estrutura_anterior) = std::vector<Periodo>();
+						lista_estrutura_copia.at(indice_estrutura_anterior).smartEnupla.at(tipo_periodo_final_estrutura_anterior) = std::vector<TipoValor>();
+					}
+
+					periodo_final_estrutura_anterior = novo_periodo_final_estrutura_anterior;
+					tipo_periodo_final_estrutura_anterior = novo_tipo_periodo_final_estrutura_anterior;
+
+				} // while (periodo_final_estrutura_anterior > periodo_anterior) {
+
+				lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_final = tipo_periodo_final_estrutura_anterior;
+
+				if (status_inclusao_iterador == 0) {
+
+					if (tipo_periodo_final_estrutura_anterior == tipo_periodo_iterador) {
+						lista_estrutura_copia.at(indice_estrutura_anterior).iteradores_finais.at(tipo_periodo_final_estrutura_anterior).at(0) = a_iterador;
+						lista_estrutura_copia.at(indice_estrutura_anterior).smartEnupla.at(tipo_periodo_final_estrutura_anterior).push_back(a_valor);
+					}
+
+					else {
+						lista_estrutura_copia.at(indice_estrutura_anterior).iteradores_iniciais.at(tipo_periodo_iterador) = std::vector<Periodo>(1, a_iterador);
+						lista_estrutura_copia.at(indice_estrutura_anterior).iteradores_finais.at(tipo_periodo_iterador) = std::vector<Periodo>(1, a_iterador);
+						lista_estrutura_copia.at(indice_estrutura_anterior).smartEnupla.at(tipo_periodo_iterador) = std::vector<TipoValor>(1, a_valor);
+					}
+
+					lista_estrutura_copia.at(indice_estrutura_anterior).tipo_iterador_final = tipo_periodo_iterador;
+
+				} // if (status_inclusao_iterador == 0) {
+			} // if (tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) {
+			
+			//
+			// Adequacao estrutura posterior
+			//
+			if (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum) {
+
+				TipoPeriodo tipo_periodo_inicial_estrutura_posterior = lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_inicial;
+				Periodo periodo_inicial_estrutura_posterior = lista_estrutura_copia.at(indice_estrutura_posterior).iteradores_iniciais.at(tipo_periodo_inicial_estrutura_posterior).at(0);
+
+				while (periodo_inicial_estrutura_posterior < periodo_posterior) {
+
+					Periodo novo_periodo_inicial_estrutura_posterior = periodo_inicial_estrutura_posterior;
+					incrementarIterador(novo_periodo_inicial_estrutura_posterior);
+
+					TipoPeriodo novo_tipo_periodo_inicial_estrutura_posterior = novo_periodo_inicial_estrutura_posterior.getTipoPeriodo();
+
+					if (novo_tipo_periodo_inicial_estrutura_posterior == tipo_periodo_inicial_estrutura_posterior) {
+						lista_estrutura_copia.at(indice_estrutura_posterior).iteradores_iniciais.at(tipo_periodo_inicial_estrutura_posterior).at(0) = novo_periodo_inicial_estrutura_posterior;
+						lista_estrutura_copia.at(indice_estrutura_posterior).smartEnupla.at(tipo_periodo_inicial_estrutura_posterior).erase(lista_estrutura_copia.at(indice_estrutura_posterior).smartEnupla.at(tipo_periodo_inicial_estrutura_posterior).begin());
+					}
+					else {
+						lista_estrutura_copia.at(indice_estrutura_posterior).iteradores_iniciais.at(tipo_periodo_inicial_estrutura_posterior) = std::vector<Periodo>();
+						lista_estrutura_copia.at(indice_estrutura_posterior).iteradores_finais.at(tipo_periodo_inicial_estrutura_posterior) = std::vector<Periodo>();
+						lista_estrutura_copia.at(indice_estrutura_posterior).smartEnupla.at(tipo_periodo_inicial_estrutura_posterior) = std::vector<TipoValor>();
+					}
+			
+					periodo_inicial_estrutura_posterior = novo_periodo_inicial_estrutura_posterior;
+					tipo_periodo_inicial_estrutura_posterior = novo_tipo_periodo_inicial_estrutura_posterior;
+
+				} // while (periodo_inicial_estrutura_posterior > periodo_posterior) {
+
+				lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_inicial = tipo_periodo_inicial_estrutura_posterior;
+
+				if (status_inclusao_iterador == 1) {
+
+					if (tipo_periodo_inicial_estrutura_posterior == tipo_periodo_iterador) {
+						lista_estrutura_copia.at(indice_estrutura_posterior).iteradores_iniciais.at(tipo_periodo_inicial_estrutura_posterior).at(0) = a_iterador;
+						lista_estrutura_copia.at(indice_estrutura_posterior).smartEnupla.at(tipo_periodo_inicial_estrutura_posterior).push_back(a_valor);
+					}
+
+					else {
+						lista_estrutura_copia.at(indice_estrutura_posterior).iteradores_iniciais.at(tipo_periodo_iterador) = std::vector<Periodo>(1, a_iterador);
+						lista_estrutura_copia.at(indice_estrutura_posterior).iteradores_finais.at(tipo_periodo_iterador) = std::vector<Periodo>(1, a_iterador);
+						lista_estrutura_copia.at(indice_estrutura_posterior).smartEnupla.at(tipo_periodo_iterador) = std::vector<TipoValor>(1, a_valor);
+					}
+
+					lista_estrutura_copia.at(indice_estrutura_posterior).tipo_iterador_inicial = tipo_periodo_iterador;
+
+				} // if (status_inclusao_iterador == 1) {
+			} // if (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum) {
+
+			lista_estrutura = lista_estrutura_copia;
+			numero_elementos = numero_elementos - iteradores.size() + 1;
+
+		} // try{
+		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::alterarValorSeAlterarIterador(" + getFullString(a_iterador) + ",a_tipo_valor): \n" + std::string(erro.what())); }
+	}
+
 
 	void setElemento(Periodo a_iterador, TipoValor a_valor) {
 		try { 
@@ -1051,6 +1431,7 @@ public:
 		} // try{
 		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::at(" + getString(a_iterador) + "): \n" + std::string(erro.what())); }
 	}; // TipoValor getElemento(Periodo a_iterador)const {
+
 
 	void random_shuffle() {
 		for (int estrutura = 0; estrutura < int(lista_estrutura.size()); estrutura++) {
@@ -1217,6 +1598,18 @@ private:
 
 	int getIndiceEstrutura(Periodo a_periodo) const {
 		try {
+			const int indice = getIndiceEstruturaSeExistir(a_periodo);
+
+			if (indice < 0)
+				throw std::invalid_argument("Nao existem estruturas definidas para o periodo " + getFullString(a_periodo));
+
+			return indice;
+		}
+		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::getIndiceEstrutura(" + getString(a_periodo) + "): \n" + std::string(erro.what())); }
+	}
+
+	int getIndiceEstruturaSeExistir(Periodo a_periodo) const {
+		try {
 
 			bool procurar_em_todas_as_estruturas = false;
 
@@ -1248,14 +1641,14 @@ private:
 					}
 				}//for (int estrutura = 0; estrutura < int(lista_estrutura.size()); estrutura++) {
 				
-				throw std::invalid_argument("Nao existem estruturas definidas para o periodo " + getFullString(a_periodo));
+				
 
 			}//if (a_periodo.estrutura == 0 || procurar_em_todas_as_estruturas) {
 
 			return -1;
 			
 		} // try{
-		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::getIndiceEstrutura(" + getString(a_periodo) + "): \n" + std::string(erro.what())); }
+		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::getIndiceEstruturaSeExistir(" + getString(a_periodo) + "): \n" + std::string(erro.what())); }
 	}; // int getIndice(Periodo a_iterador, const int a_estrutura) const {
 
 	int getIndice(Periodo a_iterador, const int a_estrutura) const {
@@ -1273,14 +1666,14 @@ private:
 				throw std::invalid_argument("Alocacao deve ser maior que 0.");
 			numero_elementos = 0;
 
-			inicializacaoEstruturaPeriodo(false, a_alocacao);
+			inicializacaoEstruturaPeriodo(-1, a_alocacao);
 
 		}
 		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::inicializacao(" + getFullString(a_alocacao) + "): \n" + std::string(erro.what())); }
 	}; // void inicializacao(const int a_alocacao) {
 
 
-	void inicializacaoEstruturaPeriodo(bool a_inserir_inicio_lista, const int a_alocacao) {
+	void inicializacaoEstruturaPeriodo(const int a_insercao, const int a_alocacao) {
 		try {
 			if (a_alocacao < 0)
 				throw std::invalid_argument("Alocacao deve ser maior que 0.");
@@ -1300,10 +1693,13 @@ private:
 
 			estruturaPeriodo.tipoEstruturaPeriodo = TipoEstruturaPeriodo_flat;
 
-			if (a_inserir_inicio_lista)
-				lista_estrutura.insert(lista_estrutura.begin(), estruturaPeriodo);
-			else
+			// Final lista
+			if ((a_insercao < 0) || (lista_estrutura.size() == 0))
 				lista_estrutura.push_back(estruturaPeriodo);
+			// Decorrer lista
+			else 
+				lista_estrutura.insert(lista_estrutura.begin() + a_insercao, estruturaPeriodo);
+
 		}
 		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::inicializacaoEstruturaPeriodo(" + getFullString(a_alocacao) + "): \n" + std::string(erro.what())); }
 	}; // void inicializacaoEstruturaPeriodo(const int a_alocacao) {

--- a/src/C_SmartEnupla.h
+++ b/src/C_SmartEnupla.h
@@ -230,7 +230,7 @@ public:
 		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::decrementarIterador(" + getString(a_iterador) + "): \n" + std::string(erro.what())); }
 	} // void operator++(Periodo &a_periodo) const {
 
-	bool isProximoIterador(const TipoIterador a_iterador) {
+	bool isProximoIterador(const TipoIterador a_iterador) const{
 		try {
 			if (TipoIterador(getIteradorFinal() + 1) == a_iterador)
 				return true;
@@ -238,6 +238,27 @@ public:
 		} // try{
 		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::isProximoIterador(" + getString(a_iterador) + "): \n" + std::string(erro.what())); }
 	}
+
+	bool isIteradorValido(const TipoIterador a_iterador) const{
+		try {
+			if (size() == 0)
+				return false;
+			if ((a_iterador < getIteradorInicial()) || (getIteradorFinal() < a_iterador))
+				return false;
+			return true;
+		} // try{
+		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::isIteradorValido(" + getString(a_iterador) + "): \n" + std::string(erro.what())); }
+	}
+
+
+	std::vector<TipoIterador> getIteradores(const TipoIterador a_iterador)const {
+		try {
+
+			return std::vector<TipoIterador>();
+
+		} // try{
+		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::getIteradores(" + getFullString(a_iterador) + "): \n" + std::string(erro.what())); }
+	} // SmartEnupla<Periodo, bool> getIteradores(const Periodo a_periodo)const {
 
 	std::string str() { return "SmartEnupla<iterador,valor>"; }
 
@@ -327,7 +348,7 @@ public:
 					if (a_matriz_interna.at(0).size() != a_matriz_interna.at(a_matriz_interna.size() - 1).size())
 						preencher_todas_linhas = false;
 
-					for (int l = a_matriz_interna.size() - 1; l >= 0; l--) {
+					for (int l = int(a_matriz_interna.size()) - 1; l >= 0; l--) {
 						if (preencher_todas_linhas)
 							a_matriz_interna.at(l).insert(a_matriz_interna.at(l).begin(), getString(iterador));
 						else {
@@ -364,7 +385,7 @@ public:
 				else
 					a_matriz_interna.push_back(std::vector<std::string>(a_enupla.size(), ""));
 
-				const int l = a_matriz_interna.size() - 1;
+				const int l = int(a_matriz_interna.size()) - 1;
 
 				int i = 0;
 				for (Iterador iterador = iteradorInicial; iterador <= iteradorFinal; a_enupla.incrementarIterador(iterador)) {
@@ -905,13 +926,26 @@ public:
 		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::decrementarIterador(" + getString(a_periodo) + "): \n" + std::string(erro.what())); }
 	} // void operator++(Periodo &a_periodo) const {
 
-	bool isProximoIterador(const Periodo a_iterador) {
+	bool isProximoIterador(const Periodo a_iterador) const {
 		try {
 			if (Periodo(a_iterador.getTipoPeriodo(), getIteradorFinal() + 1) == a_iterador)
 				return true;
 			return false;
 		} // try{
 		catch (const std::exception & erro) { throw std::invalid_argument("SmartEnupla::isProximoIterador(" + getString(a_iterador) + "): \n" + std::string(erro.what())); }
+	}
+
+	bool isIteradorValido(const Periodo a_iterador) const {
+		try {
+			if (size() == 0)
+				return false;
+			else if ((a_iterador < getIteradorInicial()) || (getIteradorFinal() < a_iterador))
+				return false;
+			else if (getIndiceEstruturaSeExistir(a_iterador) == -1)
+				return false;
+			return true;
+		} // try{
+		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::isIteradorValido(" + getString(a_iterador) + "): \n" + std::string(erro.what())); }
 	}
 
 	void addElemento(TipoValor a_valor) {
@@ -1143,7 +1177,7 @@ public:
 			else if ((tipo_estrutura_anterior != TipoEstruturaPeriodo_Nenhum) && (tipo_estrutura_posterior == TipoEstruturaPeriodo_Nenhum)) {
 
 				// Remove estruturas dos periodos que sairao
-				const int nro_estruturas_a_remover = lista_estrutura_copia.size() - (indice_estrutura_anterior + 1);
+				const int nro_estruturas_a_remover = int(lista_estrutura_copia.size()) - (indice_estrutura_anterior + 1);
 				for (int i = 0; i < nro_estruturas_a_remover; i++)
 					lista_estrutura_copia.pop_back();
 
@@ -1368,7 +1402,7 @@ public:
 			} // if (tipo_estrutura_posterior != TipoEstruturaPeriodo_Nenhum) {
 
 			lista_estrutura = lista_estrutura_copia;
-			numero_elementos = numero_elementos - iteradores.size() + 1;
+			numero_elementos = numero_elementos - int(iteradores.size()) + 1;
 
 		} // try{
 		catch (const std::exception& erro) { throw std::invalid_argument("SmartEnupla::alterarValorSeAlterarIterador(" + getFullString(a_iterador) + ",a_tipo_valor): \n" + std::string(erro.what())); }
@@ -1611,8 +1645,8 @@ private:
 	int getIndiceEstruturaSeExistir(Periodo a_periodo) const {
 		try {
 
-			bool procurar_em_todas_as_estruturas = false;
-
+			bool procurar_em_todas_as_estruturas = true;
+			/*
 			if (a_periodo.estrutura > 0) {
 
 				if (lista_estrutura.size() > a_periodo.estrutura) {
@@ -1628,17 +1662,24 @@ private:
 					procurar_em_todas_as_estruturas = true;
 
 			}//if (a_periodo.estrutura > 0) {
-
+			*/
 			if (a_periodo.estrutura == 0 || procurar_em_todas_as_estruturas) {//Procura em todas as estruturas até encontrar
 
 				const int numero_estruturas = int(lista_estrutura.size());
 				
+				const TipoPeriodo tipo_periodo_iterador = a_periodo.getTipoPeriodo();
+
 				for (int pos = 0; pos < numero_estruturas; pos++) {
 
-					if (lista_estrutura.at(pos).iteradores_iniciais.at(lista_estrutura.at(pos).tipo_iterador_inicial).at(0) <= a_periodo \
-						&& lista_estrutura.at(pos).iteradores_finais.at(lista_estrutura.at(pos).tipo_iterador_final).at(0) >= a_periodo) {
-						return pos;							
+					if (lista_estrutura.at(pos).iteradores_iniciais.at(tipo_periodo_iterador).size() > 0) {
+
+						if ((lista_estrutura.at(pos).iteradores_iniciais.at(tipo_periodo_iterador).at(0) <= a_periodo) && \
+						   (a_periodo <= lista_estrutura.at(pos).iteradores_finais.at(tipo_periodo_iterador).at(0))){
+							return pos;
+						}
+
 					}
+
 				}//for (int estrutura = 0; estrutura < int(lista_estrutura.size()); estrutura++) {
 				
 				


### PR DESCRIPTION
Estruturas que armazenam elementos do solver foram generalizadas para auto expandirem para frente e para trás, com funcionamento de maneira esparsa.

No caso de estruturas com iteradores períodos, períodos do tipo meia_hora são utilizados para completarem a sequência esparsa da estrutura. Esses períodos eventualmente podem ser alterados juntamente com seu conteúdo. Períodos já alocados com algum elemento do solver não são passíveis de alteração.

Os testes foram realizados com a remoção das estruturas de pré alocação e adição direta (assíncrona) das variáveis de decisão YH e QDEF