### PR TITLE
Correção de erros de compilação

### DIFF
--- a/SPTLNX/CMakeLists.txt
+++ b/SPTLNX/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/COIN/dist/inclu
 
 #set(LINK_FLAGS "-L/opt/gurobi912/linux64/lib -lgurobi_c++ -lgurobi91 -L${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/COIN/dist/lib -lCbcSolver -lCbc -lCgl -lOsiClp -lClpSolver -lClp -lOsi -lCoinUtils -lcoinlapack -lcoinblas -lbz2 -lz -lgfortran -lgomp -lquadmath -ldl -lpthread")
 
-set(LINK_FLAGS "-L${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/COIN/dist/lib -lCbc -lCgl -lOsiClp -lClp -lOsi -lCoinUtils -lcoinlapack -lcoinblas -lbz2 -lz -lgfortran -lgomp -lquadmath -ldl -lpthread")
+set(LINK_FLAGS "-L${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/COIN/dist/lib -lCbc -lCgl -lOsiClp -lClp -lOsi -lCoinUtils -lcoinlapack -lcoinblas -lbz2 -lz -lgfortran -lgomp -lquadmath -ldl -lpthread -lreadline")
 
 set(SPT_SOURCES ../src/SPT_main.cpp
                 ../src/C_Afluencia.cpp

--- a/src/C_ModeloOtimizacaoElementos.h
+++ b/src/C_ModeloOtimizacaoElementos.h
@@ -229,7 +229,7 @@ void ModeloOtimizacao::imprimirValorPrimalPorEstagioPorCenario##Elem##_##Nome##_
 		DECLARAR_CONDICAO_RETORNO_ImprimirPrimal_##ImprimirPrimal \
 		a_entradaSaidaDados.setDiretorioSaida(a_entradaSaidaDados.getDiretorioSaida() + "//" + std::string(#Elem)  + std::string(#Nome) + "_" + std::string(#Nro)); \
 		const std::string nome_arquivo = std::string(std::string(#Elem) + std::string(#Nome) + "_" + std::string(#Nro) + "_primal_" + a_nome_arquivo + ".csv"); \
-		a_entradaSaidaDados.imprimirArquivoCSV_SmartEnupla(nome_arquivo, SmartEnupla<int,int>::getDadosAsString(##Nro, vlrP_e_c_##Elem##_##Nome##_##Nro.at(a_TSS))); \
+		a_entradaSaidaDados.imprimirArquivoCSV_SmartEnupla(nome_arquivo, SmartEnupla<int,int>::getDadosAsString(Nro, vlrP_e_c_##Elem##_##Nome##_##Nro.at(a_TSS))); \
 		vlrP_e_c_##Elem##_##Nome##_##Nro.at(a_TSS) = \
 		Valores(DECLARAR_ALOCAR_ENUPLA_ITER) DECLARAR_ALOCAR_ENUPLA_CONST_##Nro SmartEnupla<IdRealizacao, SmartEnupla<IdCenario, double>>>>>>>>>>>>();\
 	} \
@@ -240,7 +240,7 @@ void ModeloOtimizacao::imprimirValorDualPorEstagioPorCenario##Elem##_##Nome##_##
 		DECLARAR_CONDICAO_RETORNO_ImprimirDual_##ImprimirDual \
 		a_entradaSaidaDados.setDiretorioSaida(a_entradaSaidaDados.getDiretorioSaida() + "//" + std::string(#Elem)  + std::string(#Nome) + "_" + std::string(#Nro)); \
 		const std::string nome_arquivo = std::string(std::string(#Elem) + std::string(#Nome) + "_" + std::string(#Nro) + "_dual_" + a_nome_arquivo + ".csv"); \
-		a_entradaSaidaDados.imprimirArquivoCSV_SmartEnupla(nome_arquivo, SmartEnupla<int,int>::getDadosAsString(##Nro, vlrD_e_c_##Elem##_##Nome##_##Nro.at(a_TSS))); \
+		a_entradaSaidaDados.imprimirArquivoCSV_SmartEnupla(nome_arquivo, SmartEnupla<int,int>::getDadosAsString(Nro, vlrD_e_c_##Elem##_##Nome##_##Nro.at(a_TSS))); \
 		vlrD_e_c_##Elem##_##Nome##_##Nro.at(a_TSS) = \
 		Valores(DECLARAR_ALOCAR_ENUPLA_ITER) DECLARAR_ALOCAR_ENUPLA_CONST_##Nro SmartEnupla<IdRealizacao, SmartEnupla<IdCenario, double>>>>>>>>>>>>();\
 	} \
@@ -293,7 +293,7 @@ void ModeloOtimizacao::consolidarResultados##Elem##_##Nome##_##Nro(const TipoSub
 			std::vector<std::string> lista_arquivos(a_maiorIdProcesso, "");\
 			for (IdProcesso idProcesso = IdProcesso_mestre; idProcesso <= a_maiorIdProcesso; idProcesso++) \
 				lista_arquivos.at(getRank(idProcesso)) = std::string(std::string(#Elem) + std::string(#Nome) + "_" + std::string(#Nro) + "_primal_" + getFullString(idProcesso) + ".csv"); \
-			a_entradaSaidaDados.imprimirConsolidacaoHorizontalCSV(nome_arquivo, lista_arquivos, ##Nro, true); \
+			a_entradaSaidaDados.imprimirConsolidacaoHorizontalCSV(nome_arquivo, lista_arquivos, Nro, true); \
 		} \
 		if (getboolFromChar(#ImprimirDual)){ \
 			a_entradaSaidaDados.setDiretorioSaida(diretorio + "//" + std::string(#Elem) + std::string(#Nome) + "_" + std::string(#Nro)); \
@@ -301,7 +301,7 @@ void ModeloOtimizacao::consolidarResultados##Elem##_##Nome##_##Nro(const TipoSub
 			std::vector<std::string> lista_arquivos(a_maiorIdProcesso, "");\
 			for (IdProcesso idProcesso = IdProcesso_mestre; idProcesso <= a_maiorIdProcesso; idProcesso++) \
 				lista_arquivos.at(getRank(idProcesso)) = std::string(std::string(#Elem) + std::string(#Nome) + "_" + std::string(#Nro) + "_dual_" + getFullString(idProcesso) + ".csv"); \
-			a_entradaSaidaDados.imprimirConsolidacaoHorizontalCSV(nome_arquivo, lista_arquivos, ##Nro, true); \
+			a_entradaSaidaDados.imprimirConsolidacaoHorizontalCSV(nome_arquivo, lista_arquivos, Nro, true); \
 		} \
 	} \
 	catch (const std::exception& erro) { throw std::invalid_argument("ModeloOtimizacao::consolidarResultados" + std::string(#Elem) + "_" + std::string(#Nome) + "_" + std::string(#Nro) + "(" + getFullString(a_maiorIdProcesso) + ",a_entradaSaidaDados): \n" + std::string(erro.what())); } \

--- a/src/SPT_main.cpp
+++ b/src/SPT_main.cpp
@@ -289,6 +289,7 @@ int main(int argc, char *argv[]) {
 		std::cout << std::endl;
 		std::cout << std::endl;
 		std::cout << ":~(  Excecao encontrada na execucao do modelo!" << std::endl << std::endl;
+		std::cout << erro.what() << std::endl;
 
 		try {
 			std::ofstream escritaStream;


### PR DESCRIPTION
Na macro DECLARAR_IMPRIMIR_VALOR, definida em C_ModeloOtimizacaoElementos.h, o parâmetro "Nro" estava sendo usado de forma equivocada. Além disso, foi incluída "readline" na lista de bibliotecas a serem ligadas (em SPTLNX/CMakeLists.txt) e a mensagem da exceção capturada durante a execução do modelo passa a ser exibida.