### PR TITLE
Correções na inicialização

### DIFF
--- a/src/C_Hidreletrica.h
+++ b/src/C_Hidreletrica.h
@@ -56,7 +56,7 @@
 	  m(Hidreletrica,  AttComum,  penalidade_afluencia_incremental,                               double,          0,          max,               5000,         sim) \
       m(Hidreletrica,  AttComum,         penalidade_vazao_retirada,                               double,          0,          max,              10000,         sim) \
 	  m(Hidreletrica,  AttComum,          penalidade_volume_minimo,                               double,          0,          max,              10000,         sim) \
-	  m(Hidreletrica,  AttComum,     penalidade_volume_util_minimo,                               double,          0,          max,                600,         não) \
+	  m(Hidreletrica,  AttComum,     penalidade_volume_util_minimo,                               double,          0,          max,                600,         nao) \
 	  m(Hidreletrica,  AttComum,             penalidade_evaporacao,                               double,          0,          max,              10000,         sim) \
       m(Hidreletrica,  AttComum,        penalidade_potencia_minima,                               double,          0,          max,               5000,         sim) \
       m(Hidreletrica,  AttComum,      considerar_tempo_viagem_agua,                               bool,        false,         true,              false,         nao) \

--- a/src/C_LeituraCEPEL_DESSEM.cpp
+++ b/src/C_LeituraCEPEL_DESSEM.cpp
@@ -869,7 +869,8 @@ void LeituraCEPEL::leitura_CADUSIH_201904_NW25_DC29_DES16(Dados& a_dados, const 
 					}//for (int conjunto = 0; conjunto < uhe.numConjuntos; conjunto++) {
 
 					//Calcula a queda_referencia_usina como a ponderaçao da queda_referencia por conjunto de acordo ao número de máquinas de cada conjunto dividido pelo numero total de máquinas
-					queda_referencia_usina /= numero_unidades_usina;
+					if( numero_unidades_usina > 0 )
+						queda_referencia_usina /= numero_unidades_usina;
 					a_dados.vetorHidreletrica.att(idHidreletrica).setAtributo(AttComumHidreletrica_queda_referencia, queda_referencia_usina);
 
 					// TRATAMENTO CONJUNTO HIDRAULICO 60 HZ ITAIPU QUE ESTÁ CONECTADO NO NÓ IVAIPORÃ 

--- a/src/C_ModeloOtimizacao_multiestagio_estocastico.cpp
+++ b/src/C_ModeloOtimizacao_multiestagio_estocastico.cpp
@@ -168,9 +168,9 @@ void ModeloOtimizacao::formularModeloOtimizacao(Dados& a_dados, EntradaSaidaDado
 			setMatriz(AttMatrizModeloOtimizacao_horizonte_estudo, horizonte_estudo_por_estagio);
 			setMatriz(AttMatrizModeloOtimizacao_horizonte_espaco_amostral_hidrologico, horizonte_processo_estocastico_hidrologico_por_estagio);
 
-			setVetor(AttVetorModeloOtimizacao_custo_total, SmartEnupla<IdEstagio, double>(estagio_inicial, std::vector<double>(int(estagio_final) - int(estagio_inicial) + 1, NAN)));
-			setVetor(AttVetorModeloOtimizacao_custo_imediato, SmartEnupla<IdEstagio, double>(estagio_inicial, std::vector<double>(int(estagio_final) - int(estagio_inicial) + 1, NAN)));
-			setVetor(AttVetorModeloOtimizacao_custo_futuro, SmartEnupla<IdEstagio, double>(estagio_inicial, std::vector<double>(int(estagio_final) - int(estagio_inicial) + 1, NAN)));
+			setVetor_forced(AttVetorModeloOtimizacao_custo_total, SmartEnupla<IdEstagio, double>(estagio_inicial, std::vector<double>(int(estagio_final) - int(estagio_inicial) + 1, NAN)));
+			setVetor_forced(AttVetorModeloOtimizacao_custo_imediato, SmartEnupla<IdEstagio, double>(estagio_inicial, std::vector<double>(int(estagio_final) - int(estagio_inicial) + 1, NAN)));
+			setVetor_forced(AttVetorModeloOtimizacao_custo_futuro, SmartEnupla<IdEstagio, double>(estagio_inicial, std::vector<double>(int(estagio_final) - int(estagio_inicial) + 1, NAN)));
 
 			setMatriz(AttMatrizModeloOtimizacao_realizacao_solucao_proxy, SmartEnupla<IdEstagio, SmartEnupla<IdRealizacao, int>>(estagio_inicial, std::vector<SmartEnupla<IdRealizacao, int>>(int(estagio_final) - int(estagio_inicial) + 1, SmartEnupla<IdRealizacao, int>())));
 


### PR DESCRIPTION
- Substituição de "não" por "nao" (indicando valor não obrigatório) na declaração de penalidade_volume_util_minimo.
- Correção do cálculo de queda de hidrelétricas.
- Correção na atribuição de NAN aos custos total, imediato e futuro.